### PR TITLE
Add pushPop and popPush functionality

### DIFF
--- a/heapify.mjs
+++ b/heapify.mjs
@@ -168,6 +168,22 @@ export default class Heapify {
         return poppedKey;
     }
 
+    popPush(key, priority) {
+        if (this.length === 0) {
+            this.push(key, priority);
+            return undefined;
+        }
+
+        const poppedKey = this._keys[ROOT_INDEX];
+        
+        this._keys[ROOT_INDEX] = key;
+        this._priorities[ROOT_INDEX] = priority;
+
+        this.bubbleDown(ROOT_INDEX);
+
+        return poppedKey;
+    }
+
     peekPriority() {
         return this._priorities[ROOT_INDEX];
     }

--- a/heapify.mjs
+++ b/heapify.mjs
@@ -149,6 +149,25 @@ export default class Heapify {
         return key;
     }
 
+    pushPop(key, priority) {
+        if (this.length === this._capacity) {
+            throw new Error("Heap has reached capacity, can't push new items");
+        }
+
+        if (this.length === 0 || this._priorities[ROOT_INDEX] > priority) {
+            return key;
+        }
+
+        const poppedKey = this._keys[ROOT_INDEX];
+        
+        this._keys[ROOT_INDEX] = key;
+        this._priorities[ROOT_INDEX] = priority;
+
+        this.bubbleDown(ROOT_INDEX);
+
+        return poppedKey;
+    }
+
     peekPriority() {
         return this._priorities[ROOT_INDEX];
     }

--- a/test/heapify.mjs
+++ b/test/heapify.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 
 import assert from "assert";
 import Heapify from "../heapify.mjs";

--- a/test/heapify.mjs
+++ b/test/heapify.mjs
@@ -271,4 +271,98 @@ describe("Heapify", () => {
         const queue = new Heapify();
         assert.strictEqual(String(queue), "(empty queue)");
     });
+
+    it("should pushPop correctly when new priority is smaller than min", () => {
+        const queue = new Heapify();
+        queue.push(1, 20);
+        const popped = queue.pushPop(2, 10);
+        
+        assert.strictEqual(popped, 2);
+        assert.strictEqual(queue.toString(), "[20]");
+    });
+
+    it("should pushPop correctly when new priority is larger than min", () => {
+        const queue = new Heapify();
+        queue.push(1, 10);
+        const popped = queue.pushPop(2, 20);
+        
+        assert.strictEqual(popped, 1);
+        assert.strictEqual(queue.toString(), "[20]");
+    });
+
+    it("should have consistent behavior on pushPop when priority is equal to min", () => {
+        const queue1 = new Heapify();
+        queue1.push(1, 10);
+        const popped1 = queue1.pushPop(2, 10);
+        const peek1 = queue1.peek();
+
+        const queue2 = new Heapify();
+        queue2.push(1, 10);
+        queue2.push(2, 10);
+        const popped2 = queue2.pop();
+        const peek2 = queue2.peek();
+        assert.strictEqual(popped1, popped2);
+        assert.strictEqual(peek1, peek2);
+    });
+
+    it("should pushPop correctly when new queue is empty", () => {
+        const queue = new Heapify();
+        const popped = queue.pushPop(1, 10);
+
+        assert.strictEqual(popped, 1);
+        assert.strictEqual(queue.size, 0);
+    });
+
+    it("should not be able to pushPop new items over capacity", () => {
+        const queue = new Heapify(1);
+        assert.strictEqual(queue.size, 0);
+        queue.push(1, 10);
+        assert.strictEqual(queue.size, 1);
+        assert.throws(() => queue.pushPop(2, 20));
+        assert.strictEqual(queue.size, 1);
+    });
+
+    it("should popPush correctly when new priority is larger than min", () => {
+        const queue = new Heapify();
+        queue.push(1, 20);
+        const popped = queue.popPush(2, 10);
+        
+        assert.strictEqual(popped, 1);
+        assert.strictEqual(queue.toString(), "[10]");
+    });
+
+    it("should have consistent behavior on popPush when priority is equal to min", () => {
+        const queue1 = new Heapify();
+        queue1.push(1, 10);
+        const popped1 = queue1.popPush(2, 10);
+        const peek1 = queue1.peek();
+
+        const queue2 = new Heapify();
+        queue2.push(1, 10);
+        const popped2 = queue2.pop();
+        queue2.push(2, 10);
+        const peek2 = queue2.peek();
+        assert.strictEqual(popped1, popped2);
+        assert.strictEqual(peek1, peek2);
+    });
+
+    it("should popPush correctly when new queue is empty", () => {
+        const queue = new Heapify();
+        const popped = queue.popPush(1, 10);
+
+        assert.strictEqual(popped, undefined);
+        assert.strictEqual(queue.peek(), 1);
+    });
+
+    it("should be able to popPush when items at capacity", () => {
+        const queue = new Heapify(2);
+        queue.push(1, 3);
+        queue.push(2, 5);
+        
+        const popped = queue.popPush(3, 4);
+
+        assert.strictEqual(popped, 1);
+        assert.strictEqual(queue.size, 2);
+        assert.strictEqual(queue.toString(), "[4 5]");
+    });
 });


### PR DESCRIPTION
- Add methods for pushPop, popPush

For cases where you need to push and pop in either order, one followed by the other with no need for the middle state, these methods can can be used.
It performs better than just one followed by the other since it uses only a single _bubble_ operation compared to two otherwise.